### PR TITLE
Add CountUp animation and remove mega menu submenus

### DIFF
--- a/src/components/Intelligence/IntelligenceCore.jsx
+++ b/src/components/Intelligence/IntelligenceCore.jsx
@@ -6,6 +6,7 @@ import { Award, Target, Users, Brain, TrendingUp, Globe } from "lucide-react";
 import gsap from "gsap";
 import ScrollTrigger from "gsap/ScrollTrigger";
 import { motion } from "framer-motion";
+import CountUp from "react-countup";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -421,23 +422,26 @@ export default function IntelligenceCore() {
       >
         {[
           {
-            number: "200+",
+            number: 15,
+            label: "Global Centers",
+            gradient: "linear-gradient(to right, #0199D3, #0199D3)",
+          },
+          {
+            number: 200,
+            suffix: "+",
             label: "Solutions",
             gradient: "linear-gradient(to right, #3b82f6, #2563eb)",
           },
           {
-            number: "1800+",
-            label: "Engineers",
-            gradient: "linear-gradient(to right, #0199D3, #0199D3)",
-          },
-          {
-            number: "250+",
+            number: 250,
+            suffix: "+",
             label: "Architects",
             gradient: "linear-gradient(to right, #3b82f6, #2563eb)",
           },
           {
-            number: "15",
-            label: "Global Centers",
+            number: 1800,
+            suffix: "+",
+            label: "Engineers",
             gradient: "linear-gradient(to right, #0199D3, #0199D3)",
           },
         ].map((stat, idx) => (
@@ -462,13 +466,26 @@ export default function IntelligenceCore() {
                 variant="h5"
                 fontWeight={300}
                 sx={{
-                 
                   WebkitBackgroundClip: "text",
                   color: "white!important",
                   mb: 1,
                 }}
               >
-                {stat.number}
+                {isVisible ? (
+                  <>
+                    <CountUp
+                      start={0}
+                      end={stat.number}
+                      duration={2.5}
+                      delay={idx * 0.3}
+                      useEasing={true}
+                      separator=","
+                    />
+                    {stat.suffix || ""}
+                  </>
+                ) : (
+                  `${stat.number}${stat.suffix || ""}`
+                )}
               </Typography>
               <Typography variant="caption" sx={{ color: "#fff!important" }}>
                 {stat.label}

--- a/src/components/megaMenu/MegaMenuIntellectt.jsx
+++ b/src/components/megaMenu/MegaMenuIntellectt.jsx
@@ -1425,14 +1425,14 @@ function MegaMenuIntellectt() {
               <MegaMenuSection key={item.title}>
                 <MegaMenuSectionTitle
                   isExpanded={isExpanded}
-                  onClick={["Our Journey", "Leadership Team", "Global Presence"].includes(item.title) ? () => { if (item.url) { window.location.href = item.url; } } : () => toggleMegaMenuSection(menuName, item.title)}
-                  style={["Our Journey", "Leadership Team", "Global Presence"].includes(item.title) ? { cursor: 'pointer' } : {}}
+                  onClick={([menuName === "Industries", menuName === "Resources", "Our Journey", "Leadership Team", "Global Presence"].includes(true) || ["Our Journey", "Leadership Team", "Global Presence"].includes(item.title)) ? () => { if (item.url) { window.location.href = item.url; } } : () => toggleMegaMenuSection(menuName, item.title)}
+                  style={([menuName === "Industries", menuName === "Resources", "Our Journey", "Leadership Team", "Global Presence"].includes(true) || ["Our Journey", "Leadership Team", "Global Presence"].includes(item.title)) ? { cursor: 'pointer' } : {}}
                 >
                   {item.title}
-                  {!["Our Journey", "Leadership Team", "Global Presence"].includes(item.title) && <ChevronDown />}
+                  {!(menuName === "Industries" || menuName === "Resources" || ["Our Journey", "Leadership Team", "Global Presence"].includes(item.title)) && <ChevronDown />}
                 </MegaMenuSectionTitle>
 
-                {!["Our Journey", "Leadership Team", "Global Presence"].includes(item.title) && (
+                {!(menuName === "Industries" || menuName === "Resources" || ["Our Journey", "Leadership Team", "Global Presence"].includes(item.title)) && (
                   <MegaMenuSectionContent isExpanded={isExpanded}>
                     {item.hasDropdown && (item.companies || item.services) ? (
                       <MegaMenuGrid>


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR addresses two main requirements:
1. Implement animated counting from 0 to target numbers for statistics boxes with proper ordering
2. Remove submenus from Industries and Resources sections in the mega menu, making them direct links

## Code changes
- **IntelligenceCore.jsx**: 
  - Added `react-countup` library for number animations
  - Reordered statistics array in ascending order (15, 200+, 250+, 1800+)
  - Implemented CountUp component with staggered delays and easing
  - Added suffix support for "+" symbols
- **MegaMenuIntellectt.jsx**:
  - Modified click handlers to treat Industries and Resources sections as direct links
  - Removed chevron down arrows for Industries and Resources menu items
  - Disabled submenu content rendering for Industries and Resources sections

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/264c0e082d9849fea26e505cf07dd77d/vibe-garden)

👀 [Preview Link](https://264c0e082d9849fea26e505cf07dd77d-vibe-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>264c0e082d9849fea26e505cf07dd77d</projectId>-->
<!--<branchName>vibe-garden</branchName>-->